### PR TITLE
feat(endpoint): Add simple authentication middleware

### DIFF
--- a/endpoint/config/config_test.go
+++ b/endpoint/config/config_test.go
@@ -47,6 +47,7 @@ func TestNew(t *testing.T) {
 				"ENDPOINT_REPORTER_PUBSUB_NAME":    "reports-test",
 				"ENDPOINT_REPORTER_PUBSUB_TOPIC":   "create-test",
 				"ENDPOINT_REPORTER_PUBSUB_TIMEOUT": "5s",
+				"ENDPOINT_SECURITY_KEYS":           "key1,key2",
 			},
 			want: &Configuration{
 				Server: Server{
@@ -55,6 +56,12 @@ func TestNew(t *testing.T) {
 					ReadTimeout:  time.Second * 10,
 					WriteTimeout: time.Second * 10,
 					IdleTimeout:  time.Second * 10,
+					Security: Security{
+						Keys: map[string]struct{}{
+							"key1": {},
+							"key2": {},
+						},
+					},
 				},
 				Reporter: Reporter{
 					Type:          "pubsub-test",

--- a/endpoint/go.mod
+++ b/endpoint/go.mod
@@ -6,7 +6,7 @@ replace github.com/RedeployAB/container-apps-dapr/common => ../common
 
 require (
 	github.com/RedeployAB/container-apps-dapr/common v0.0.0-00010101000000-000000000000
-	github.com/caarlos0/env/v6 v6.10.1
+	github.com/caarlos0/env/v8 v8.0.0
 	github.com/dapr/go-sdk v1.7.0
 	github.com/go-logr/logr v1.2.4
 	github.com/google/go-cmp v0.5.9

--- a/endpoint/go.sum
+++ b/endpoint/go.sum
@@ -1,5 +1,5 @@
-github.com/caarlos0/env/v6 v6.10.1 h1:t1mPSxNpei6M5yAeu1qtRdPAK29Nbcf/n3G7x+b3/II=
-github.com/caarlos0/env/v6 v6.10.1/go.mod h1:hvp/ryKXKipEkcuYjs9mI4bBCg+UI0Yhgm5Zu0ddvwc=
+github.com/caarlos0/env/v8 v8.0.0 h1:POhxHhSpuxrLMIdvTGARuZqR4Jjm8AYmoi/JKlcScs0=
+github.com/caarlos0/env/v8 v8.0.0/go.mod h1:7K4wMY9bH0esiXSSHlfHLX5xKGQMnkH5Fk4TDSSSzfo=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/dapr/go-sdk v1.7.0 h1:SJC8layk2eKuJ8N+S84DtYpP4fgVugu8sUAliGu6/nM=

--- a/endpoint/main.go
+++ b/endpoint/main.go
@@ -32,6 +32,9 @@ func main() {
 		ReadTimeout:  cfg.Server.ReadTimeout,
 		WriteTimeout: cfg.Server.WriteTimeout,
 		IdleTimeout:  cfg.Server.IdleTimeout,
+		Security: server.Security{
+			Keys: cfg.Server.Security.Keys,
+		},
 	})
 	if err != nil {
 		log.Error(err, "Error creating server.")

--- a/endpoint/server/middleware.go
+++ b/endpoint/server/middleware.go
@@ -1,0 +1,23 @@
+package server
+
+import "net/http"
+
+const (
+	authHeader = "X-API-Key"
+)
+
+// authenticate is a middleware that checks for a valid API key in the request.
+func authenticate(keys map[string]struct{}, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		key := r.Header.Get(authHeader)
+		if len(key) == 0 {
+			http.Error(w, "missing auth header", http.StatusUnauthorized)
+			return
+		}
+		if _, ok := keys[key]; !ok {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/endpoint/server/middleware_test.go
+++ b/endpoint/server/middleware_test.go
@@ -1,0 +1,94 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestAuthenticate tests the authenticate middleware with table-driven tests.
+func TestAuthenticate(t *testing.T) {
+	var tests = []struct {
+		name  string
+		input struct {
+			keys map[string]struct{}
+			req  func() *http.Request
+		}
+		wantCode int
+	}{
+		{
+			name: "valid key",
+			input: struct {
+				keys map[string]struct{}
+				req  func() *http.Request
+			}{
+				keys: map[string]struct{}{
+					"valid-key": {},
+				},
+				req: func() *http.Request {
+					req := httptest.NewRequest("GET", "/", nil)
+					req.Header.Set(authHeader, "valid-key")
+					return req
+				},
+			},
+			wantCode: http.StatusOK,
+		},
+		{
+			name: "missing key",
+			input: struct {
+				keys map[string]struct{}
+				req  func() *http.Request
+			}{
+				keys: map[string]struct{}{
+					"valid-key": {},
+				},
+				req: func() *http.Request {
+					req := httptest.NewRequest("GET", "/", nil)
+					return req
+				},
+			},
+			wantCode: http.StatusUnauthorized,
+		},
+		{
+			name: "invalid key",
+			input: struct {
+				keys map[string]struct{}
+				req  func() *http.Request
+			}{
+				keys: map[string]struct{}{
+					"valid-key": {},
+				},
+				req: func() *http.Request {
+					req := httptest.NewRequest("GET", "/", nil)
+					req.Header.Set(authHeader, "invalid-key")
+					return req
+				},
+			},
+			wantCode: http.StatusUnauthorized,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Create a mock response recorder.
+			rr := httptest.NewRecorder()
+
+			// Create a mock handler.
+			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+
+			// Create a new request.
+			req := test.input.req()
+
+			// Call the authenticate middleware with the mock handler.
+			authenticate(test.input.keys, handler).ServeHTTP(rr, req)
+
+			// Check the status code.
+			if status := rr.Code; status != test.wantCode {
+				t.Errorf("handler returned wrong status code: got %v want %v\n",
+					status, test.wantCode)
+			}
+		})
+	}
+}

--- a/endpoint/server/routes.go
+++ b/endpoint/server/routes.go
@@ -2,5 +2,5 @@ package server
 
 // routes setups registers routes and handlers for the server.
 func (s server) routes() {
-	s.router.Handle("/reports", s.reportHandler())
+	s.router.Handle("/reports", authenticate(s.security.Keys, s.reportHandler()))
 }

--- a/endpoint/server/server.go
+++ b/endpoint/server/server.go
@@ -45,12 +45,19 @@ type server struct {
 	router     router
 	log        log
 	reporter   report.Service
+	security   Security
+}
+
+// Security contains keys for the authenticate middleware.
+type Security struct {
+	Keys map[string]struct{}
 }
 
 // Options for the server.
 type Options struct {
 	Logger       log
 	Reporter     report.Service
+	Security     Security
 	Host         string
 	Port         int
 	ReadTimeout  time.Duration
@@ -92,6 +99,7 @@ func New(router router, options Options) (*server, error) {
 		httpServer: srv,
 		log:        options.Logger,
 		reporter:   options.Reporter,
+		security:   options.Security,
 	}, nil
 }
 

--- a/endpoint/server/server_test.go
+++ b/endpoint/server/server_test.go
@@ -55,6 +55,11 @@ func TestNew(t *testing.T) {
 				IdleTimeout:  time.Second * 20,
 				Logger:       mockLogger{},
 				Reporter:     &mockReporter{},
+				Security: Security{
+					Keys: map[string]struct{}{
+						"key": {},
+					},
+				},
 			},
 			want: &server{
 				httpServer: &http.Server{
@@ -67,6 +72,11 @@ func TestNew(t *testing.T) {
 				router:   &mockRouter{},
 				log:      mockLogger{},
 				reporter: &mockReporter{},
+				security: Security{
+					Keys: map[string]struct{}{
+						"key": {},
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
This PR adds a simple authentication middleware.

Set the environment variable `ENDPOINT_SECURITY_KEYS` to a comma-separated list of keys that should grant access.
Any key that is set in the environment variable can be used when calling the endpoint with the header:
`X-API-Key: <key>`.