### PR TITLE
iac: add container apps to terraform definitions

### DIFF
--- a/deployment/terraform/application-environment/main.tf
+++ b/deployment/terraform/application-environment/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.53.0"
+      version = "3.81.0"
     }
   }
 }

--- a/deployment/terraform/application-environment/resources.container.app.tf
+++ b/deployment/terraform/application-environment/resources.container.app.tf
@@ -1,3 +1,29 @@
+locals {
+  worker_scale_queue_settings = {
+    name = "queue-scale-rule"
+    metadata = {
+      namespace    = azurerm_servicebus_namespace.main.name
+      queueName    = "create"
+      messageCount = "1"
+    }
+  }
+
+  worker_scale_pubsub_settings = {
+    name = "topic-scale-rule"
+    metadata = {
+      namespace        = azurerm_servicebus_namespace.main.name
+      subscriptionName = var.worker_container_app.name
+      topicName        = "create"
+    }
+  }
+
+  worker_scale_settings = (
+    var.messaging_system == "queue"
+    ? local.worker_scale_queue_settings
+    : local.worker_scale_pubsub_settings
+  )
+}
+
 resource "azurerm_container_app_environment" "main" {
   name                = var.container_app_environment_name
   resource_group_name = local.resource_group.name
@@ -72,5 +98,144 @@ resource "azurerm_container_app_environment_dapr_component" "output" {
   metadata {
     name  = "azureClientId"
     value = azurerm_user_assigned_identity.main.client_id
+  }
+}
+
+resource "azurerm_container_app" "endpoint" {
+  count = var.provision_container_apps ? 1 : 0
+
+  name                         = var.endpoint_container_app.name
+  resource_group_name          = local.resource_group.name
+  container_app_environment_id = azurerm_container_app_environment.main.id
+  revision_mode                = "Single"
+
+  identity {
+    type = "UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.main.id
+    ]
+  }
+
+  registry {
+    server   = azurerm_container_registry.main.login_server
+    identity = azurerm_user_assigned_identity.main.id
+  }
+
+  dapr {
+    app_id       = var.endpoint_container_app.name
+    app_port     = var.endpoint_container_app.port
+    app_protocol = "grpc"
+  }
+
+  ingress {
+    external_enabled = true
+    target_port      = var.endpoint_container_app.port
+    traffic_weight {
+      latest_revision = true
+      percentage      = 100
+    }
+  }
+
+  secret {
+    name  = "endpoint-security-keys"
+    value = join(",", var.endpoint_security_keys)
+  }
+
+  template {
+    container {
+      name   = var.endpoint_container_app.name
+      image  = "${azurerm_container_registry.main.login_server}/${var.endpoint_container_app.image}"
+      cpu    = var.endpoint_container_app.cpu
+      memory = var.endpoint_container_app.memory
+
+      env {
+        name        = "ENDPOINT_SECURITY_KEYS"
+        secret_name = "endpoint-security-keys"
+      }
+
+      env {
+        name  = "ENDPOINT_REPORTER_TYPE"
+        value = var.messaging_system
+      }
+    }
+
+    min_replicas = var.endpoint_container_app.min_replicas
+    max_replicas = var.endpoint_container_app.max_replicas
+
+    http_scale_rule {
+      name                = "http-scale-rule"
+      concurrent_requests = 50
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      template[0].container[0].image
+    ]
+  }
+}
+
+resource "azurerm_container_app" "worker" {
+  count = var.provision_container_apps ? 1 : 0
+
+  name                         = var.worker_container_app.name
+  resource_group_name          = local.resource_group.name
+  container_app_environment_id = azurerm_container_app_environment.main.id
+  revision_mode                = "Single"
+
+  identity {
+    type = "UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.main.id
+    ]
+  }
+
+  registry {
+    server   = azurerm_container_registry.main.login_server
+    identity = azurerm_user_assigned_identity.main.id
+  }
+
+  dapr {
+    app_id       = var.worker_container_app.name
+    app_port     = var.worker_container_app.port
+    app_protocol = "grpc"
+  }
+
+  secret {
+    name  = "servicebus-connection-string"
+    value = azurerm_servicebus_namespace_authorization_rule.scaling.primary_connection_string
+  }
+
+  template {
+    container {
+      name   = var.worker_container_app.name
+      image  = "${azurerm_container_registry.main.login_server}/${var.worker_container_app.image}"
+      cpu    = var.worker_container_app.cpu
+      memory = var.worker_container_app.memory
+
+      env {
+        name  = "WORKER_TYPE"
+        value = var.messaging_system
+      }
+    }
+
+    min_replicas = var.worker_container_app.min_replicas
+    max_replicas = var.worker_container_app.max_replicas
+
+    custom_scale_rule {
+      name             = local.worker_scale_settings.name
+      custom_rule_type = "azure-servicebus"
+      metadata         = local.worker_scale_settings.metadata
+      authentication {
+        secret_name       = "servicebus-connection-string"
+        trigger_parameter = "connection"
+      }
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      template[0].container[0].image
+    ]
   }
 }

--- a/deployment/terraform/application-environment/variables.tf
+++ b/deployment/terraform/application-environment/variables.tf
@@ -103,8 +103,9 @@ variable "endpoint_container_app" {
 }
 
 variable "endpoint_security_keys" {
-  type    = list(string)
-  default = []
+  type      = list(string)
+  sensitive = true
+  default   = []
 }
 
 variable "worker_container_app" {

--- a/deployment/terraform/application-environment/variables.tf
+++ b/deployment/terraform/application-environment/variables.tf
@@ -82,6 +82,46 @@ variable "container_app_environment_name" {
   description = "Name of the container app environment."
 }
 
+variable "provision_container_apps" {
+  type    = bool
+  default = false
+}
+
+variable "endpoint_container_app" {
+  type = object({
+    name         = optional(string, "endpoint")
+    image        = optional(string, "endpoint:1.0.0")
+    cpu          = optional(number, 0.25)
+    memory       = optional(string, "0.5Gi")
+    port         = optional(number, 3000)
+    min_replicas = optional(number, 0)
+    max_replicas = optional(number, 3)
+  })
+  default = {
+    name = "endpoint"
+  }
+}
+
+variable "endpoint_security_keys" {
+  type    = list(string)
+  default = []
+}
+
+variable "worker_container_app" {
+  type = object({
+    name         = optional(string, "worker")
+    image        = optional(string, "worker:1.0.0")
+    cpu          = optional(number, 0.25)
+    memory       = optional(string, "0.5Gi")
+    port         = optional(number, 3001)
+    min_replicas = optional(number, 0)
+    max_replicas = optional(number, 3)
+  })
+  default = {
+    name = "worker"
+  }
+}
+
 variable "messaging_system" {
   type = string
   validation {


### PR DESCRIPTION
Some updates have been done to the azurerm provider for Terraform and the resources for container apps has better support for scaling (custom scale rules). Thus the container apps will be deployed with Terraform instead of a bash script.

New variables introduced:
- `provision_container_apps` - Set if container apps should be provisioned, set this to `false` at first apply, so that images can be pushed to the container registry.
- `endpoint_container_app` - Settings for `endpoint` application.
- `worker_container_app` - Settings for `worker` application.
- `endpoint_security_keys` - Security keys for `endpoint`
